### PR TITLE
NEW: Custom code mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,7 @@ Install the library in your project from the command line: `npm i @digitallingui
 **Option 3:** Install `scription2dlx` in your project using **npm** (see above), and then include the script in your HTML with a script tag. You may choose to use either the bundled distribution or the distribution that supports ES modules:
 
 ```html
-<!-- Bundled version -->
 <script src=node_modules/@digitallinguistics/scription2dlx/scription2dlx.js></script>
-
-<!-- ES modules -->
-<script src=node_modules/@digitallinguistics/scription2dlx/dist/index.mjs type=module></script>
 ```
 
 ## Usage
@@ -81,11 +77,12 @@ const text = scription2dlx(data, { /* options */ });
 
 Option | Default   | Description
 ------ | --------- | -----------
+codes  | `{}`      | This option allows you to use custom backslash codes in your interlinear glosses. It should be a hash containing the scription code as a key (without a leading backslash), and the custom code as the value; ex: `"txn": "t"` will allow you to write `\t` instead of `\txn` for transcription lines.
 parser | undefined | A YAML parser to use to parse the header of a scription document. If none is present, the header will be provided as a string in the `header` property of the returned object.
 
 ## Using as a Dependency
 
-If you would like to include `scription2dlx` as a dependency in your own library, you can use the files in the `/src` directory to transpile / bundle `scription2dlx` with your own code. The source code for `scription2dlx` is written using the latest JavaScript syntax and ES modules.
+If you would like to include `scription2dlx` as a dependency in your own library, you can use the files in the `/src` directory to transpile / bundle `scription2dlx` with your own code. The source code for `scription2dlx` is written using ES modules and the latest JavaScript syntax.
 
 [AJV]:       https://www.npmjs.com/package/ajv
 [DaFoDiL]:   https://format.digitallinguistics.io

--- a/src/constants/types.mjs
+++ b/src/constants/types.mjs
@@ -8,4 +8,5 @@ export default [
   `tln`,
   `trs`,
   `txn`,
+  `w`,
 ];

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,19 +1,47 @@
+/* eslint-disable
+  sort-keys,
+*/
+
+import { isString }    from './utilities/index.mjs';
 import parseHeader     from './parseHeader.mjs';
 import parseUtterances from './parseUtterances.mjs';
+
+const defaultCodes = {
+  sp:   `sp`,
+  trs:  `trs`,
+  txn:  `txn`,
+  w:    `w`,
+  phon: `phon`,
+  m:    `m`,
+  gl:   `gl`,
+  wlt:  `wlt`,
+  lit:  `lit`,
+  tln:  `tln`,
+  n:    `n`,
+};
 
 /**
  * Converts a scription-format text to DLx format
  * @param  {String} scription The text of the Scription file to parse
+ * @param  {Object} options   An options hash
  * @return {Object}           Returns a plain JavaScript object formatted according to the DLx Text format
  */
-export default function scription2dlx(scription = ``, { parser } = {}) {
+export default function scription2dlx(scription = ``, { codes: customCodes = {}, parser } = {}) {
 
   const isEmpty = scription.trim() === ``;
 
   if (isEmpty) return {};
 
+  if (!(customCodes instanceof Object && Object.values(customCodes).every(isString))) {
+    const e = new TypeError(`The "codes" option must be an Object whose values are Strings.`);
+    e.name  = scription2dlx.name;
+    throw e;
+  }
+
+  const codes = Object.assign({}, defaultCodes, customCodes || {});
+
   const header     = parseHeader(scription, parser);
-  const utterances = parseUtterances(scription);
+  const utterances = parseUtterances(scription, codes);
 
   return { ...header, utterances };
 

--- a/src/parseUtterance/parseCustom.mjs
+++ b/src/parseUtterance/parseCustom.mjs
@@ -2,26 +2,23 @@
   no-param-reassign,
 */
 
-import { types } from '../constants/index.mjs';
+import { types as scriptionTypes } from '../constants/index.mjs';
 
 import {
   getLineType,
   groupLines,
 } from '../utilities/index.mjs';
 
-const singleLines = [
-  `phon`,
-  `sp`,
-];
-
 /**
  * Extracts any custom lines from the lines hash and returns them in an object
- * @param  {Object} lines The lines hash
+ * @param  {Object} lineCodes The line codes hash
+ * @param  {Object} lines     The lines hash
  * @return {Object}
  */
-export default function parseCustom(lines) {
+export default function parseCustom(codesMap, lines) {
 
   const lineCodes = Object.keys(lines);
+  const types     = scriptionTypes.map(type => codesMap[type]);
 
   const customTypes = lineCodes
   .map(getLineType)
@@ -30,6 +27,8 @@ export default function parseCustom(lines) {
     hash[type] = groupLines(type, lines);
     return hash;
   }, {});
+
+  const singleLines = [codesMap.phon, codesMap.sp];
 
   const customCodes = lineCodes.filter(code => {
     const type         = getLineType(code);

--- a/src/parseUtterance/parseLiteral.mjs
+++ b/src/parseUtterance/parseLiteral.mjs
@@ -5,12 +5,15 @@ import {
 
 /**
  * Parses, validates, and cleans the literal translation lines
- * @param  {Object}        lines The lines hash
+ * @param  {String}        lineCode The line code to use for the phonetic line
+ * @param  {Object}        lines    The lines hash
  * @return {String|Object}
  */
-export default function parseLiteral(lines) {
-  let data = groupLines(`lit`, lines);
+export default function parseLiteral(lineCode, lines) {
+  let data = groupLines(lineCode, lines);
   if (!data) return null;
+  // NB: Do not use the lineCode variable here
+  // cleanBrackets accept an abstract type, not a line code, as its first argument
   data = cleanBrackets(`lit`, data);
   return data;
 }

--- a/src/parseUtterance/parseMorphemes/getDuplicateMorphemes.mjs
+++ b/src/parseUtterance/parseMorphemes/getDuplicateMorphemes.mjs
@@ -25,30 +25,25 @@ function getDuplicateGlosses(code, morphemes) {
 }
 
 /**
- * Gets the line code of the first gloss line in a morpheme
- * @param  {Object} morpheme The morpheme to get the code for
- * @return {String}
- */
-function getFirstGlossCode({ gloss }) {
-  const isBareString = isString(gloss);
-  return isBareString ? `string` : Object.keys(gloss)[0];
-}
-
-/**
  * Get an array of arrays of morphemes with the same gloss
  * @param  {Array} morphemes The array of morphemes to check for duplicates
  * @return {Array}           Returns an array of arrays of duplicate morphemes
  */
 export default function getDuplicateMorphemes(morphemes) {
 
-  const glossToCheck     = getFirstGlossCode(morphemes[0]);
+  const [{ gloss }] = morphemes;
+
+  if (!gloss) return [];
+
+  const isBareString     = isString(gloss);
+  const glossToCheck     = isBareString ? `string` : Object.keys(gloss)[0];
   const duplicateGlosses = getDuplicateGlosses(glossToCheck, morphemes);
 
   if (!duplicateGlosses) return [];
 
-  return duplicateGlosses.map(gl => morphemes.filter(({ gloss }) => {
-    if (isString(gloss)) return gloss === gl;
-    return gloss[glossToCheck] === gl;
+  return duplicateGlosses.map(gl => morphemes.filter(({ gloss: g }) => {
+    if (isString(g)) return g === gl;
+    return g[glossToCheck] === gl;
   }));
 
 }

--- a/src/parseUtterance/parseMorphemes/separateInfix.mjs
+++ b/src/parseUtterance/parseMorphemes/separateInfix.mjs
@@ -2,14 +2,20 @@ import { getLineType } from '../../utilities/index.mjs';
 
 /**
  * Checks a Morpheme object for infixes, and returns an array of two morphemes if one is present
- * @param  {Object}       morpheme The morepheme object to check for infixes
- * @return {Object|Array}          Returns an array of two morpheme objects, in order, if an infixed morpheme is present in the original morpheme object. Returns the original morpheme object otherwise.
+ * @param  {String}       glossLineCode The line code to use for the gloss line
+ * @param  {Object}       morpheme      The morepheme object to check for infixes
+ * @return {Object|Array}               Returns an array of two morpheme objects, in order, if an infixed morpheme is present in the original morpheme object. Returns the original morpheme object otherwise.
  */
-export default function separateInfix(morpheme) {
+export default function separateInfix(glossLineCode, morpheme) {
 
-  const infixRegExp    = /(?<pre>.*)<(?<infix>.+)>(?<post>.*)/u;
-  const entries        = Object.entries(morpheme);
-  const [, firstGloss] = entries.find(([code]) => getLineType(code) === `gl`);
+
+  const infixRegExp = /(?<pre>.*)<(?<infix>.+)>(?<post>.*)/u;
+  const entries     = Object.entries(morpheme);
+  const glossLines  = entries.find(([code]) => getLineType(code) === glossLineCode);
+
+  if (!glossLines) return morpheme;
+
+  const [, firstGloss] = glossLines;
   const match          = firstGloss.match(infixRegExp);
 
   if (!match) return morpheme;

--- a/src/parseUtterance/parseNotes.mjs
+++ b/src/parseUtterance/parseNotes.mjs
@@ -5,22 +5,23 @@ import {
 
 /**
  * Accepts the lines hash and returns an array of DLx Note objects
- * @param  {Object} lines The lines hash
- * @return {Array}        Returns the "notes" property of the utterance (or null)
+ * @param  {String} lineCode The line code to use for notes
+ * @param  {Object} lines    The lines hash
+ * @return {Array}           Returns the "notes" property of the utterance (or null)
  */
-export default function parseNotes(lines) {
+export default function parseNotes(lineCode, lines) {
 
-  const noteLines = getLines(`n`, lines);
+  const noteLines = getLines(lineCode, lines);
 
   if (!noteLines) return [];
 
-  const numberedRegExp = /n-[0-9]/u;
+  const numberedRegExp = new RegExp(`${lineCode}-[0-9]`, `u`);
   const noteRegExp     = /^(?:\s*(?<source>.+?)\s*:\s*)?(?<text>.+)$/u;
 
   return Object.entries(noteLines)
   .map(([rawCode, data]) => {
 
-    const code                = rawCode.replace(numberedRegExp, `n`);
+    const code                = rawCode.replace(numberedRegExp, lineCode);
     const [, language = `en`] = code.split(`-`, 2);
     const { source, text }    = data.match(noteRegExp).groups;
 

--- a/src/parseUtterance/parsePhonetic.mjs
+++ b/src/parseUtterance/parsePhonetic.mjs
@@ -7,5 +7,7 @@ import { cleanBrackets } from '../utilities/index.mjs';
  */
 export default function parsePhonetic(line) {
   if (!line) return null;
+  // NB: Do not use the lineCode variable here:
+  // cleanBrackets accepts an abstract type, not a line code, as the first argument
   return cleanBrackets(`phon`, line);
 }

--- a/src/parseUtterance/parseTranscript.mjs
+++ b/src/parseUtterance/parseTranscript.mjs
@@ -2,10 +2,11 @@ import { groupLines } from '../utilities/index.mjs';
 
 /**
  * Extracts, validates, and cleans the transcript lines from the lines hash
- * @param  {Object}        lines The lines hash
+ * @param  {String}        lineCode The line code for the transcript lines
+ * @param  {Object}        lines    The lines hash
  * @return {String|Object}
  */
-export default function parseTranscript(lines) {
-  const data = groupLines(`trs`, lines);
+export default function parseTranscript(lineCode, lines) {
+  const data = groupLines(lineCode, lines);
   return data || null;
 }

--- a/src/parseUtterance/parseTranscription.mjs
+++ b/src/parseUtterance/parseTranscription.mjs
@@ -1,7 +1,28 @@
 import {
   cleanBrackets,
   groupLines,
+  isString,
 } from '../utilities/index.mjs';
+
+function replaceSpaces(str) {
+  return str.replace(/\s+/gu, ` `);
+}
+
+/**
+ * Accepts a DLx Transcription object and removes any extra white spaces from the transcriptions
+ * @param  {Object} txn
+ * @return {Object}
+ */
+function removeExtraWhiteSpace(txn) {
+
+  if (isString(txn)) return replaceSpaces(txn);
+
+  return Object.entries(txn).reduce((hash, [lang, data]) => {
+    hash[lang] = data.replace(/\s+/gu, ` `); // eslint-disable-line no-param-reassign
+    return hash;
+  }, {});
+
+}
 
 /**
  * Extracts, validates, and cleans the transcription lines from the lines hash
@@ -9,8 +30,14 @@ import {
  * @return {String|Object}
  */
 export default function parseTranscription(lines) {
+
   let data = groupLines(`txn`, lines);
+
   if (!data) return null;
+
   data = cleanBrackets(`txn`, data);
+  data = removeExtraWhiteSpace(data);
+
   return data;
+
 }

--- a/src/parseUtterance/parseTranscription.mjs
+++ b/src/parseUtterance/parseTranscription.mjs
@@ -26,15 +26,17 @@ function removeExtraWhiteSpace(txn) {
 
 /**
  * Extracts, validates, and cleans the transcription lines from the lines hash
- * @param  {Object}        lines The lines hash
+ * @param  {String}        lineCode The code to use for transcription lines
+ * @param  {Object}        lines    The lines hash
  * @return {String|Object}
  */
-export default function parseTranscription(lines) {
+export default function parseTranscription(lineCode, lines) {
 
-  let data = groupLines(`txn`, lines);
+  let data = groupLines(lineCode, lines);
 
   if (!data) return null;
 
+  // NB: Do not use lineCode here; cleanBrackets takes an abstract type, not a line code, as its first argument
   data = cleanBrackets(`txn`, data);
   data = removeExtraWhiteSpace(data);
 

--- a/src/parseUtterance/parseTranslation.mjs
+++ b/src/parseUtterance/parseTranslation.mjs
@@ -4,11 +4,12 @@ import {
 
 /**
  * Extracts, validates, and cleans the translation lines from the lines hash
- * @param  {Object}        lines The lines hash
+ * @param  {String}        lineCode The line code to use for translations lines
+ * @param  {Object}        lines    The lines hash
  * @return {String|Object}
  */
-export default function parseTranslation(lines) {
-  const data = groupLines(`tln`, lines);
+export default function parseTranslation(lineCode, lines) {
+  const data = groupLines(lineCode, lines);
   if (!data) return null;
   return data;
 }

--- a/src/parseUtterances.mjs
+++ b/src/parseUtterances.mjs
@@ -18,7 +18,7 @@ function getUtterancesString(text) {
  * @param  {String} scription The scription text
  * @return {Array}
  */
-export default function parseUtterances(scription) {
+export default function parseUtterances(scription, codes) {
 
   const utterancesString = getUtterancesString(scription);
 
@@ -27,7 +27,7 @@ export default function parseUtterances(scription) {
   const blankLinesRegExp  = /(?:[ \t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]*\r?\n){2,}/gsu;
   const utterancesStrings = utterancesString.split(blankLinesRegExp);
   const schema            = getSchema(utterancesStrings[0]);
-  const parse             = utteranceString => parseUtterance(utteranceString, schema);
+  const parse             = utteranceString => parseUtterance(utteranceString, schema, codes);
 
   return utterancesString
   .split(blankLinesRegExp)

--- a/test/lines/glosses.test.js
+++ b/test/lines/glosses.test.js
@@ -241,5 +241,23 @@ describe(`glosses`, () => {
     expect(w4m.gloss).toBe(`null`);
 
   });
+  /* eslint-enable max-statements */
+
+  it(`populates both word and morpheme glosses`, () => {
+
+    const text = `
+    \\m  waxt-qungu qasi
+    \\gl day-one    man
+    `;
+
+    const { utterances: [{ words: [word] }] } = convert(text);
+
+    expect(word.gloss).toBe(`day-one`);
+
+    const { morphemes: [morpheme] } = word;
+
+    expect(morpheme.gloss).toBe(`day`);
+
+  });
 
 });

--- a/test/lines/transcription.test.js
+++ b/test/lines/transcription.test.js
@@ -52,6 +52,19 @@ describe(`phomemic transcription (utterance)`, () => {
 
   });
 
+  it(`removes extraneous whitespace`, () => {
+
+    const text = `
+    \\txn waxdungu     qasi
+    \\tln one day a man
+    `;
+
+    const { utterances: [utterance] } = convert(text);
+
+    expect(utterance.transcription).toBe(`waxdungu qasi`);
+
+  });
+
 });
 
 describe(`phonemic transcription (word)`, () => {

--- a/test/lines/transcription.test.js
+++ b/test/lines/transcription.test.js
@@ -2,7 +2,7 @@
  * This file applies tests for the phonemic transcription line (`\txn`)
  */
 
-describe(`phomemic transcription`, () => {
+describe(`phomemic transcription (utterance)`, () => {
 
   it(`should remove phonemic slashes`, () => {
 
@@ -35,6 +35,43 @@ describe(`phomemic transcription`, () => {
 
     expect(transcription.swad).toBe(SwadeshTranscription);
     expect(transcription.apa).toBe(APATranscription);
+
+  });
+
+  it(`should populate from the word transcriptions line`, () => {
+
+    const text = `
+    \\w  waxdungu   qasi
+    \\m  waxt-qungu qasi
+    \\gl day-one    man
+    `;
+
+    const { utterances: [utterance] } = convert(text);
+
+    expect(utterance.transcription).toBe(`waxdungu qasi`);
+
+  });
+
+});
+
+describe(`phonemic transcription (word)`, () => {
+
+  it(`may be in multiple orthographies`, () => {
+
+    const mod  = `waxdungu`;
+    const swad = `wašdungu`;
+
+    const text = `
+    \\w-mod  ${mod}
+    \\w-swad ${swad}
+    \\m      waxt-qungu
+    \\gl     day-one
+    `;
+
+    const { utterances: [{ words: [word] }] } = convert(text);
+
+    expect(word.transcription.mod).toBe(mod);
+    expect(word.transcription.swad).toBe(swad);
 
   });
 

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -291,4 +291,32 @@ describe(`interlinear gloss schema`, () => {
 
   });
 
+  it(`allows custom backslash codes`, () => {
+
+    const transcription = `waxdungu qasi`;
+    const translation   = `one day a man`;
+
+    const text = `
+    \\t  ${transcription}
+    \\wt ${transcription}
+    \\tl ${translation}
+    `;
+
+    const codes = {
+      tln: `tl`,
+      txn: `t`,
+      w:   `wt`,
+    };
+
+    const { utterances: [utterance] } = convert(text, { codes });
+
+    expect(utterance.transcription).toBe(transcription);
+    expect(utterance.translation).toBe(translation);
+
+    const { words: [word] } = utterance;
+
+    expect(word.transcription).toBe(`waxdungu`);
+
+  });
+
 });


### PR DESCRIPTION
* custom code mappings (closes #38)
* remove extraneous whitespace from transcription line (closes #37)
* `\gl` line populates both word and morpheme glosses (closes #36)